### PR TITLE
fix: correct Tamil year (Vishvavasu) calculation

### DIFF
--- a/backend/src/services/calculations/tamil_calendar.py
+++ b/backend/src/services/calculations/tamil_calendar.py
@@ -50,17 +50,11 @@ def calculate_tamil_calendar(julian_day: float) -> dict:
     rashi_index = int(sun_long_sidereal / 30)
     tamil_month = TAMIL_MONTHS[rashi_index]
 
-    # Tamil year calculation
-    # Year starts with Mesha Sankranti (Sun entering Aries)
-    # If before Chithirai (Mesha), use previous year
-    year, month, day, _ = swe.revjul(julian_day)
-
-    # Rough approximation: Tamil year = Gregorian year - 1 if before April
-    # More accurate: check if before Mesha Sankranti
-    if rashi_index < 0 or (rashi_index == 0 and sun_long_sidereal < 5):
-        tamil_year_num = year - 1
-    else:
-        tamil_year_num = year
+    # Tamil year calculation:
+    # year changes at Mesha Sankranti (sidereal Sun entering Aries, 0°).
+    # Before that transition (roughly Jan-mid Apr), use previous Gregorian year.
+    year, _, _, _ = swe.revjul(julian_day)
+    tamil_year_num = year - 1 if sun_long_sidereal >= 270 else year
 
     # Tamil year names cycle (60-year cycle)
     tamil_year_name = get_tamil_year_name(tamil_year_num)
@@ -142,9 +136,12 @@ def get_tamil_year_name(gregorian_year: int) -> str:
         "Akshaya",
     ]
 
-    # Calculate position in 60-year cycle
-    # Reference: Year 2000 = Prabhava (index 0)
-    cycle_position = (gregorian_year - 2000) % 60
+    # Calculate position in 60-year cycle.
+    # Reference alignment:
+    # - 2024-2025 Tamil year: Krodhin (index 37)
+    # - 2025-2026 Tamil year: Vishvavasu (index 38)
+    # Therefore 1987 maps to index 0 (Prabhava) for this cycle list.
+    cycle_position = (gregorian_year - 1987) % 60
 
     return TAMIL_YEAR_NAMES[cycle_position]
 

--- a/backend/tests/test_tamil_calendar.py
+++ b/backend/tests/test_tamil_calendar.py
@@ -1,0 +1,26 @@
+import swisseph as swe
+
+from src.services.calculations.tamil_calendar import (
+    calculate_tamil_calendar,
+    get_tamil_year_name,
+)
+
+
+def test_get_tamil_year_name_known_cycle_alignment():
+    assert get_tamil_year_name(2024) == "Krodhin"
+    assert get_tamil_year_name(2025) == "Vishvavasu"
+    assert get_tamil_year_name(2026) == "Parabhava"
+
+
+def test_calculate_tamil_calendar_pre_mesha_uses_previous_tamil_year():
+    # February 7, 2026 (before Mesha Sankranti) should still be the 2025 Tamil year.
+    jd = swe.julday(2026, 2, 7, 12.0)
+    result = calculate_tamil_calendar(jd)
+    assert result["tamil_year"] == "Vishvavasu"
+
+
+def test_calculate_tamil_calendar_post_mesha_uses_current_tamil_year():
+    # April 20, 2026 (after Mesha Sankranti) should be 2026 Tamil year.
+    jd = swe.julday(2026, 4, 20, 12.0)
+    result = calculate_tamil_calendar(jd)
+    assert result["tamil_year"] == "Parabhava"


### PR DESCRIPTION
## Summary
- fix Tamil year cycle anchor used for Samvatsara name mapping
- fix pre-Mesha-Sankranti year selection logic
- add focused tests for known years and Feb/Apr 2026 boundary behavior

## Why
On dates like 2026-02-07 (before Mesha Sankranti), UI showed `Vijaya` when expected year is `Vishvavasu`.

## Validation
- `PYTHONPATH=. ./venv/bin/pytest tests/test_tamil_calendar.py -q`
